### PR TITLE
Mirror of signalapp libsignal-protocol-java#62

### DIFF
--- a/java/src/main/java/org/whispersystems/libsignal/fingerprint/FingerprintGenerator.java
+++ b/java/src/main/java/org/whispersystems/libsignal/fingerprint/FingerprintGenerator.java
@@ -10,9 +10,15 @@ import org.whispersystems.libsignal.IdentityKey;
 import java.util.List;
 
 public interface FingerprintGenerator {
-  public Fingerprint createFor(String localStableIdentifier, IdentityKey localIdentityKey,
-                               String remoteStableIdentifier, IdentityKey remoteIdentityKey);
+  public Fingerprint createFor(int version,
+                               byte[] localStableIdentifier,
+                               IdentityKey localIdentityKey,
+                               byte[] remoteStableIdentifier,
+                               IdentityKey remoteIdentityKey);
 
-  public Fingerprint createFor(String localStableIdentifier, List<IdentityKey> localIdentityKey,
-                               String remoteStableIdentifier, List<IdentityKey> remoteIdentityKey);
+  public Fingerprint createFor(int version,
+                               byte[] localStableIdentifier,
+                               List<IdentityKey> localIdentityKey,
+                               byte[] remoteStableIdentifier,
+                               List<IdentityKey> remoteIdentityKey);
 }

--- a/java/src/main/java/org/whispersystems/libsignal/fingerprint/NumericFingerprintGenerator.java
+++ b/java/src/main/java/org/whispersystems/libsignal/fingerprint/NumericFingerprintGenerator.java
@@ -43,6 +43,7 @@ public class NumericFingerprintGenerator implements FingerprintGenerator {
   /**
    * Generate a scannable and displayable fingerprint.
    *
+   * @param version The version of fingerprint you are generating.
    * @param localStableIdentifier The client's "stable" identifier.
    * @param localIdentityKey The client's identity key.
    * @param remoteStableIdentifier The remote party's "stable" identifier.
@@ -50,10 +51,14 @@ public class NumericFingerprintGenerator implements FingerprintGenerator {
    * @return A unique fingerprint for this conversation.
    */
   @Override
-  public Fingerprint createFor(String localStableIdentifier, final IdentityKey localIdentityKey,
-                               String remoteStableIdentifier, final IdentityKey remoteIdentityKey)
+  public Fingerprint createFor(int version,
+                               byte[] localStableIdentifier,
+                               final IdentityKey localIdentityKey,
+                               byte[] remoteStableIdentifier,
+                               final IdentityKey remoteIdentityKey)
   {
-    return createFor(localStableIdentifier,
+    return createFor(version,
+                     localStableIdentifier,
                      new LinkedList<IdentityKey>() {{
                        add(localIdentityKey);
                      }},
@@ -70,14 +75,18 @@ public class NumericFingerprintGenerator implements FingerprintGenerator {
    * Do not trust the output of this unless you've been through the device consistency process
    * for the provided localIdentityKeys.
    *
+   * @param version The version of fingerprint you are generating.
    * @param localStableIdentifier The client's "stable" identifier.
    * @param localIdentityKeys The client's collection of physical identity keys.
    * @param remoteStableIdentifier The remote party's "stable" identifier.
    * @param remoteIdentityKeys The remote party's collection of physical identity key.
    * @return A unique fingerprint for this conversation.
    */
-  public Fingerprint createFor(String localStableIdentifier, List<IdentityKey> localIdentityKeys,
-                               String remoteStableIdentifier, List<IdentityKey> remoteIdentityKeys)
+  public Fingerprint createFor(int version,
+                               byte[] localStableIdentifier,
+                               List<IdentityKey> localIdentityKeys,
+                               byte[] remoteStableIdentifier,
+                               List<IdentityKey> remoteIdentityKeys)
   {
     byte[] localFingerprint  = getFingerprint(iterations, localStableIdentifier, localIdentityKeys);
     byte[] remoteFingerprint = getFingerprint(iterations, remoteStableIdentifier, remoteIdentityKeys);
@@ -85,18 +94,19 @@ public class NumericFingerprintGenerator implements FingerprintGenerator {
     DisplayableFingerprint displayableFingerprint = new DisplayableFingerprint(localFingerprint,
                                                                                remoteFingerprint);
 
-    ScannableFingerprint   scannableFingerprint   = new ScannableFingerprint(localFingerprint,
+    ScannableFingerprint   scannableFingerprint   = new ScannableFingerprint(version,
+                                                                             localFingerprint,
                                                                              remoteFingerprint);
 
     return new Fingerprint(displayableFingerprint, scannableFingerprint);
   }
 
-  private byte[] getFingerprint(int iterations, String stableIdentifier, List<IdentityKey> unsortedIdentityKeys) {
+  private byte[] getFingerprint(int iterations, byte[] stableIdentifier, List<IdentityKey> unsortedIdentityKeys) {
     try {
       MessageDigest digest    = MessageDigest.getInstance("SHA-512");
       byte[]        publicKey = getLogicalKeyBytes(unsortedIdentityKeys);
       byte[]        hash      = ByteUtil.combine(ByteUtil.shortToByteArray(FINGERPRINT_VERSION),
-                                                 publicKey, stableIdentifier.getBytes());
+                                                 publicKey, stableIdentifier);
 
       for (int i=0;i<iterations;i++) {
         digest.update(hash);

--- a/java/src/main/java/org/whispersystems/libsignal/fingerprint/ScannableFingerprint.java
+++ b/java/src/main/java/org/whispersystems/libsignal/fingerprint/ScannableFingerprint.java
@@ -16,11 +16,10 @@ import java.security.MessageDigest;
 
 public class ScannableFingerprint {
 
-  private static final int VERSION = 1;
-
+  private final int                  version;
   private final CombinedFingerprints fingerprints;
 
-  ScannableFingerprint(byte[] localFingerprintData, byte[] remoteFingerprintData)
+  ScannableFingerprint(int version, byte[] localFingerprintData, byte[] remoteFingerprintData)
   {
     LogicalFingerprint localFingerprint = LogicalFingerprint.newBuilder()
                                                             .setContent(ByteString.copyFrom(ByteUtil.trim(localFingerprintData, 32)))
@@ -30,8 +29,9 @@ public class ScannableFingerprint {
                                                              .setContent(ByteString.copyFrom(ByteUtil.trim(remoteFingerprintData, 32)))
                                                              .build();
 
+    this.version      = version;
     this.fingerprints = CombinedFingerprints.newBuilder()
-                                            .setVersion(VERSION)
+                                            .setVersion(version)
                                             .setLocalFingerprint(localFingerprint)
                                             .setRemoteFingerprint(remoteFingerprint)
                                             .build();
@@ -59,9 +59,9 @@ public class ScannableFingerprint {
       CombinedFingerprints scanned = CombinedFingerprints.parseFrom(scannedFingerprintData);
 
       if (!scanned.hasRemoteFingerprint() || !scanned.hasLocalFingerprint() ||
-          !scanned.hasVersion() || scanned.getVersion() != VERSION)
+          !scanned.hasVersion() || scanned.getVersion() != version)
       {
-        throw new FingerprintVersionMismatchException(scanned.getVersion(), VERSION);
+        throw new FingerprintVersionMismatchException(scanned.getVersion(), version);
       }
 
       return MessageDigest.isEqual(fingerprints.getLocalFingerprint().getContent().toByteArray(), scanned.getRemoteFingerprint().getContent().toByteArray()) &&

--- a/tests/src/test/java/org/whispersystems/libsignal/fingerprint/NumericFingerprintGeneratorTest.java
+++ b/tests/src/test/java/org/whispersystems/libsignal/fingerprint/NumericFingerprintGeneratorTest.java
@@ -1,20 +1,16 @@
 package org.whispersystems.libsignal.fingerprint;
 
-import android.util.Log;
-
 import junit.framework.TestCase;
 
 import org.whispersystems.libsignal.IdentityKey;
 import org.whispersystems.libsignal.ecc.Curve;
 import org.whispersystems.libsignal.ecc.ECKeyPair;
-import org.whispersystems.libsignal.util.Hex;
 
 import java.util.Arrays;
 
 public class NumericFingerprintGeneratorTest extends TestCase {
 
-  private static final String TAG = NumericFingerprintGeneratorTest.class.getSimpleName();
-
+  private static final int    VERSION                     = 1;
   private static final byte[] ALICE_IDENTITY              = {(byte) 0x05, (byte) 0x06, (byte) 0x86, (byte) 0x3b, (byte) 0xc6, (byte) 0x6d, (byte) 0x02, (byte) 0xb4, (byte) 0x0d, (byte) 0x27, (byte) 0xb8, (byte) 0xd4, (byte) 0x9c, (byte) 0xa7, (byte) 0xc0, (byte) 0x9e, (byte) 0x92, (byte) 0x39, (byte) 0x23, (byte) 0x6f, (byte) 0x9d, (byte) 0x7d, (byte) 0x25, (byte) 0xd6, (byte) 0xfc, (byte) 0xca, (byte) 0x5c, (byte) 0xe1, (byte) 0x3c, (byte) 0x70, (byte) 0x64, (byte) 0xd8, (byte) 0x68};
   private static final byte[] BOB_IDENTITY                = {(byte) 0x05, (byte) 0xf7, (byte) 0x81, (byte) 0xb6, (byte) 0xfb, (byte) 0x32, (byte) 0xfe, (byte) 0xd9, (byte) 0xba, (byte) 0x1c, (byte) 0xf2, (byte) 0xde, (byte) 0x97, (byte) 0x8d, (byte) 0x4d, (byte) 0x5d, (byte) 0xa2, (byte) 0x8d, (byte) 0xc3, (byte) 0x40, (byte) 0x46, (byte) 0xae, (byte) 0x81, (byte) 0x44, (byte) 0x02, (byte) 0xb5, (byte) 0xc0, (byte) 0xdb, (byte) 0xd9, (byte) 0x6f, (byte) 0xda, (byte) 0x90, (byte) 0x7b};
   private static final String DISPLAYABLE_FINGERPRINT     = "300354477692869396892869876765458257569162576843440918079131";
@@ -26,11 +22,13 @@ public class NumericFingerprintGeneratorTest extends TestCase {
     IdentityKey bobIdentityKey   = new IdentityKey(BOB_IDENTITY, 0);
 
     NumericFingerprintGenerator generator        = new NumericFingerprintGenerator(5200);
-    Fingerprint                 aliceFingerprint = generator.createFor("+14152222222", aliceIdentityKey,
-                                                                       "+14153333333", bobIdentityKey);
+    Fingerprint                 aliceFingerprint = generator.createFor(VERSION,
+                                                                       "+14152222222".getBytes(), aliceIdentityKey,
+                                                                       "+14153333333".getBytes(), bobIdentityKey);
 
-    Fingerprint bobFingerprint = generator.createFor("+14153333333", bobIdentityKey,
-                                                     "+14152222222", aliceIdentityKey);
+    Fingerprint bobFingerprint = generator.createFor(VERSION,
+                                                     "+14153333333".getBytes(), bobIdentityKey,
+                                                     "+14152222222".getBytes(), aliceIdentityKey);
 
     assertEquals(aliceFingerprint.getDisplayableFingerprint().getDisplayText(), DISPLAYABLE_FINGERPRINT);
     assertEquals(bobFingerprint.getDisplayableFingerprint().getDisplayText(), DISPLAYABLE_FINGERPRINT);
@@ -47,11 +45,13 @@ public class NumericFingerprintGeneratorTest extends TestCase {
     IdentityKey bobIdentityKey   = new IdentityKey(bobKeyPair.getPublicKey());
 
     NumericFingerprintGenerator generator        = new NumericFingerprintGenerator(1024);
-    Fingerprint                 aliceFingerprint = generator.createFor("+14152222222", aliceIdentityKey,
-                                                                       "+14153333333", bobIdentityKey);
+    Fingerprint                 aliceFingerprint = generator.createFor(VERSION,
+                                                                       "+14152222222".getBytes(), aliceIdentityKey,
+                                                                       "+14153333333".getBytes(), bobIdentityKey);
 
-    Fingerprint bobFingerprint = generator.createFor("+14153333333", bobIdentityKey,
-                                                     "+14152222222", aliceIdentityKey);
+    Fingerprint bobFingerprint = generator.createFor(VERSION,
+                                                     "+14153333333".getBytes(), bobIdentityKey,
+                                                     "+14152222222".getBytes(), aliceIdentityKey);
 
     assertEquals(aliceFingerprint.getDisplayableFingerprint().getDisplayText(),
                  bobFingerprint.getDisplayableFingerprint().getDisplayText());
@@ -72,11 +72,13 @@ public class NumericFingerprintGeneratorTest extends TestCase {
     IdentityKey mitmIdentityKey  = new IdentityKey(mitmKeyPair.getPublicKey());
 
     NumericFingerprintGenerator generator        = new NumericFingerprintGenerator(1024);
-    Fingerprint                 aliceFingerprint = generator.createFor("+14152222222", aliceIdentityKey,
-                                                                       "+14153333333", mitmIdentityKey);
+    Fingerprint                 aliceFingerprint = generator.createFor(VERSION,
+                                                                       "+14152222222".getBytes(), aliceIdentityKey,
+                                                                       "+14153333333".getBytes(), mitmIdentityKey);
 
-    Fingerprint bobFingerprint = generator.createFor("+14153333333", bobIdentityKey,
-                                                     "+14152222222", aliceIdentityKey);
+    Fingerprint bobFingerprint = generator.createFor(VERSION,
+                                                     "+14153333333".getBytes(), bobIdentityKey,
+                                                     "+14152222222".getBytes(), aliceIdentityKey);
 
     assertNotSame(aliceFingerprint.getDisplayableFingerprint().getDisplayText(),
                   bobFingerprint.getDisplayableFingerprint().getDisplayText());
@@ -93,11 +95,13 @@ public class NumericFingerprintGeneratorTest extends TestCase {
     IdentityKey bobIdentityKey   = new IdentityKey(bobKeyPair.getPublicKey());
 
     NumericFingerprintGenerator generator        = new NumericFingerprintGenerator(1024);
-    Fingerprint                 aliceFingerprint = generator.createFor("+141512222222", aliceIdentityKey,
-                                                                       "+14153333333", bobIdentityKey);
+    Fingerprint                 aliceFingerprint = generator.createFor(VERSION,
+                                                                       "+141512222222".getBytes(), aliceIdentityKey,
+                                                                       "+14153333333".getBytes(), bobIdentityKey);
 
-    Fingerprint bobFingerprint = generator.createFor("+14153333333", bobIdentityKey,
-                                                     "+14152222222", aliceIdentityKey);
+    Fingerprint bobFingerprint = generator.createFor(VERSION,
+                                                     "+14153333333".getBytes(), bobIdentityKey,
+                                                     "+14152222222".getBytes(), aliceIdentityKey);
 
     assertNotSame(aliceFingerprint.getDisplayableFingerprint().getDisplayText(),
                   bobFingerprint.getDisplayableFingerprint().getDisplayText());


### PR DESCRIPTION
Mirror of signalapp libsignal-protocol-java#62
With the introduction of UUIDs, we need to be able to generate fingerprints from raw bytes, not just strings. In addition, we need to be able to conditionally set the fingerprint version based on whether or
not we're using UUIDs.
